### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,7 +19,7 @@ display	KEYWORD2
 printError	KEYWORD2
 setWiring	KEYWORD2
 setSegment	KEYWORD2
-print KEYWORD2
+print	KEYWORD2
 printAlignedLeft	KEYWORD2
 printAlignedRight	KEYWORD2
 printNumber	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords